### PR TITLE
jxc properties in package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 
 ## Directory-based project format:
 .idea/
+
+node_modules/

--- a/lib/commands/sample.js
+++ b/lib/commands/sample.js
@@ -119,6 +119,120 @@ exports.useSample = function (sampleName, cb) {
     });
   }
 
+  var project_dir = process.cwd();
+
+  // Read installed plugins
+  var installed_plugins;
+  var plugins_json = path.join(project_dir, 'plugins/fetch.json');
+  if (fs.existsSync(plugins_json)) {
+    installed_plugins = Object.keys(require(plugins_json));
+  } else {
+    installed_plugins = [];
+  }
+
+  // Read installed platforms
+  var installed_platforms;
+  var platforms_json = path.join(project_dir, 'platforms/platforms.json');
+  if (fs.existsSync(platforms_json)) {
+    installed_platforms = Object.keys(require(platforms_json));
+  } else {
+    installed_platforms = [];
+  }
+
+  // Unused plugins (all plugins except io.jxcore.node and whitelist)
+  var unused_plugins = installed_plugins.filter(function (plugin_name) {
+    return plugin_name !== dname && plugin_name !== 'cordova-plugin-whitelist';
+  });
+
+  // Unused platforms
+  var unused_platforms = installed_platforms.slice();
+
+  /* Install platforms add plugins from sample's `package.json`
+    "jxc": {
+      "plugins": [<plugin_name>],
+      "platforms": [<platform_name>]
+    }
+  */
+  var sample_package_json = path.resolve(dir, '../package.json');
+  if (fs.existsSync(sample_package_json)) {
+    var package_json_data = require(sample_package_json);
+    if (package_json_data.jxc) {
+      var jxc_data = package_json_data.jxc;
+
+      if (jxc_data.plugins) {
+        if (jxc_data.plugins.length) {
+          // Set unused plugins
+          unused_plugins.filter(function (unused_plugin) {
+            return jxc_data.plugins.indexOf(unused_plugin) !== -1;
+          }).forEach(function (used_plugin) {
+            unused_plugins.splice(unused_plugins.indexOf(used_plugin), 1)
+          });
+
+          // Install plugins
+          Array.prototype.push.apply(commands,
+            // Skip installed plugins
+            jxc_data.plugins.filter(function (plugin_name) {
+              return installed_plugins.indexOf(plugin_name) === -1;
+            })
+            .map(function (plugin_name) {
+              return {
+                name: 'install plugins',
+                command: 'cordova plugins add ' + plugin_name,
+                caption: 'Installing ' + plugin_name + ' plugin...'
+              };
+            })
+          );
+        }
+
+        // Delete unused plugins
+        unused_plugins.forEach(function (unused_plugin) {
+          commands.push({
+            name: 'remove unused plugin',
+            command: 'cordova plugins remove ' + unused_plugin,
+            caption: 'Removing unused plugin ' + unused_plugin + '...'
+          });
+        });
+      }
+      
+      if (jxc_data.platforms) {
+        if (!jxc_data.platforms.length) {
+          throw 'Platforms can not be empty. Please add at least one platform in package.json\'s jxc.platforms property';
+        }
+
+        // Set unused platforms
+        unused_platforms.filter(function (unused_platform) {
+          return jxc_data.platforms.indexOf(unused_platform) !== -1;
+        }).forEach(function (used_platform) {
+          unused_platforms.splice(unused_platforms.indexOf(used_platform), 1)
+        });
+
+        // Install platforms
+        Array.prototype.push.apply(commands,
+          // Skip installed platforms
+          jxc_data.platforms.filter(function (platform_name) {
+            return installed_platforms.indexOf(platform_name) === -1;
+          })
+          .map(function (platform_name) {
+            return {
+              name: 'install platforms',
+              command: 'cordova platforms add ' + platform_name,
+              caption: 'Installing ' + platform_name + ' platform...'
+            };
+          })
+        );
+
+        // Delete unused platforms
+        unused_platforms.forEach(function (unused_platform) {
+          commands.push({
+            name: 'remove unused platform',
+            command: 'cordova platforms remove ' + unused_platform,
+            caption: 'Removing unused platform ' + unused_platform + '...'
+          });
+        });
+      }
+    }
+  }
+
   commands.push({
     name: 'cordova_prepare',
     command: 'cordova prepare',


### PR DESCRIPTION
Usage:

```
{
    "jxc": {
        "plugins": ["cordova-plugin-camera"],
        "platforms": ["android", "ios"]
    }
}
```

Note that jxc properties are read from sample's package json, not from `<sample>/www/jxcore/package.json`
